### PR TITLE
Update README.md to add mac shortcut key is same as win and linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Remember:
 
 - As you type GitHub Copilot will make suggestions, you can accept them by pressing Tab.
 - If nothing shows up after Copilot write some lines , press enter and wait a couple of seconds.
-- On Windows or Linux, press Ctrl + Enter, then click Open GitHub Copilot.
+- On Windows, MacOS or Linux, press Ctrl + Enter, then click Open GitHub Copilot.
 
 
 ## Pre-requisites


### PR DESCRIPTION
This PR updated the readme to clarify that the hot key to see suggestions is the same on Windows, MacOS and Linux.