### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,6 @@ Run:
 
 5. [Enabling GitHub Copilot in the CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/enabling-github-copilot-in-the-cli)
 
-6. [GitHub Copilot Badges and Certifications](https://learn.microsoft.com/en-us/training/browse/?terms=github%20copilot)
+6. [GitHub Copilot MS Learn Modules](https://learn.microsoft.com/en-us/training/browse/?terms=github%20copilot)
+
+7. [GitHub Copilot Certifications](https://resources.github.com/learn/certifications/)


### PR DESCRIPTION
Changed wording on quick links section for line 6: Changed to GitHub Copilot MS Learn Modules

Added line 7: GitHub Copilot Certification and linked to certification page